### PR TITLE
Document and verify advanced embedding recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,156 @@ Sample search result format:
 {"rank": 1, "id": "doc_0099", "score": 0.0464}
 ```
 
+## Advanced Embedding Use Cases
+
+All advanced retrieval recipes showcased in the Vector Embedding Innovations note are implemented in `embkit.lib.query_ops` and exercised by unit tests under `tests/test_query_ops.py`. The snippets below can be copy-pasted into a Python REPL (after `make setup`) to experiment with each idea.
+
+### 1. Directional Semantic Search (Query Logic)
+
+Bias a query towards a preferred concept by adding a direction vector before searching. Tune `alpha` in your YAML config under `query_ops` (`op: directional`) to control the strength of the bias.【F:embkit/lib/query_ops/__init__.py†L11-L32】【F:experiments/configs/demo.yaml†L7-L11】
+
+```python
+import numpy as np
+from embkit.lib.query_ops import directional_search
+
+q = np.array([1.0, 0.1], dtype=np.float32)
+direction = np.array([0.0, 1.0], dtype=np.float32)
+docs = np.array([[0.9, 0.0], [0.5, 0.5]], dtype=np.float32)
+
+baseline = directional_search(q, np.zeros_like(direction), docs, alpha=0.0)
+biased = directional_search(q, direction, docs, alpha=0.8)
+print(baseline[0], biased[0])  # -> 0 then 1
+```
+
+### 2. Contrastive Query Filtering (Query Logic)
+
+Subtract similarity to a negative concept to down-rank undesired matches. Configure via `op: contrastive` with a `lambda` weight and optional vector path for the negative concept.【F:embkit/lib/query_ops/__init__.py†L34-L58】【F:experiments/configs/demo.yaml†L9-L11】
+
+```python
+import numpy as np
+from embkit.lib.query_ops import contrastive_score
+
+q = np.array([0.7, 0.7], dtype=np.float32)
+neg = np.array([0.0, 1.0], dtype=np.float32)
+doc_ok = np.array([0.6, 0.0], dtype=np.float32)
+doc_bad = np.array([0.1, 0.9], dtype=np.float32)
+print(contrastive_score(q, neg, doc_ok, lam=0.5) > contrastive_score(q, neg, doc_bad, lam=0.5))
+```
+
+### 3. Compositional (Multi-Facet) Search (Query Logic)
+
+Retrieve items covering multiple facets by running sub-searches for each facet and merging hits. Combine with `compose_and`/`compose_or` if you already have aligned score vectors.【F:embkit/lib/query_ops/__init__.py†L60-L94】
+
+```python
+import numpy as np
+from embkit.lib.query_ops import facet_subsearch
+
+docs = np.array([[0.9, 0.8], [0.95, 0.1], [0.1, 0.95], [0.5, 0.5]], dtype=np.float32)
+ml = np.array([1.0, 0.0], dtype=np.float32)
+health = np.array([0.0, 1.0], dtype=np.float32)
+ranked = facet_subsearch([ml, health], docs, top_k=3)
+print(ranked)  # docs covering both facets surface first
+```
+
+### 4. Analogical Search (Query Logic)
+
+Answer analogy prompts by applying `b - a + c` and searching near the resulting vector. Use the helper `analogical_query` to stay deterministic.【F:embkit/lib/query_ops/__init__.py†L96-L109】
+
+```python
+import numpy as np
+from embkit.lib.query_ops import analogical_query
+
+emb = {
+    "king": np.array([1.0, 1.0], dtype=np.float32),
+    "queen": np.array([-1.0, 1.0], dtype=np.float32),
+    "man": np.array([1.0, 0.0], dtype=np.float32),
+    "woman": np.array([-1.0, 0.0], dtype=np.float32),
+}
+vec = analogical_query("man", "king", "woman", emb)
+```
+
+### 5. Diversity-Aware Re-ranking (MMR/DPP) (Query Logic)
+
+Apply Maximal Marginal Relevance to balance relevance and novelty in the top-k. Set `op: mmr` with your chosen `lambda` in the YAML config to activate re-ranking after initial retrieval.【F:embkit/lib/query_ops/__init__.py†L111-L137】【F:embkit/cli/search.py†L46-L65】
+
+```python
+import numpy as np
+from embkit.lib.query_ops import mmr_select
+
+q = np.random.rand(5).astype(np.float32)
+docs = np.stack([q + 0.1, q + 0.1, q * 0.8]).astype(np.float32)
+chosen = mmr_select(q, docs, k=2, lam=0.5)
+print(chosen)  # returns indices with diversity baked in
+```
+
+### 6. Temporal Decay Ranking (Query Logic)
+
+Boost recency-sensitive documents by decaying scores with age. `temporal_score` handles single documents, while `temporal` applies the decay to vectors (e.g., on the top-k candidate scores).【F:embkit/lib/query_ops/__init__.py†L139-L155】
+
+```python
+import numpy as np
+from embkit.lib.query_ops import temporal, temporal_score
+
+scores = np.array([0.8, 0.8], dtype=np.float32)
+ages = np.array([10.0, 100.0], dtype=np.float32)
+print(temporal(scores, ages, gamma=0.02))
+print(temporal_score(0.8, 10.0, gamma=0.02))
+```
+
+### 7. Personalized Search (Query Logic)
+
+Blend the query vector with a user profile to tailor results. Provide a `beta` weight to control how strong the personalization bias is.【F:embkit/lib/query_ops/__init__.py†L157-L170】
+
+```python
+import numpy as np
+from embkit.lib.query_ops import personalize, personalized_score
+
+q = np.array([0.0, 1.0], dtype=np.float32)
+user = np.array([1.0, 0.0], dtype=np.float32)
+docs = np.array([[1.0, 0.0], [-1.0, 0.0]], dtype=np.float32)
+print(personalize(q, user, docs, beta=0.5))
+print(personalized_score(q, user, docs[0], beta=0.5))
+```
+
+### 8. Multi-Vector Late Interaction (Representation & Indexing)
+
+Score documents represented by multiple vectors (e.g., token embeddings) with ColBERT-style MaxSim. Feed query token vectors and the document token matrix to `late_interaction_score` to obtain the aggregated score.【F:embkit/lib/query_ops/__init__.py†L172-L185】
+
+```python
+import numpy as np
+from embkit.lib.query_ops import late_interaction_score
+
+q_tokens = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+doc_tokens = np.array([[0.9, 0.1], [0.1, 0.95], [0.4, 0.4]], dtype=np.float32)
+print(late_interaction_score(q_tokens, doc_tokens))
+```
+
+### 9. Attribute Subspace Retrieval (Representation & Indexing)
+
+Restrict similarity to attribute-specific dimensions with `subspace_similarity`, or stack multiple subspace constraints via `polytope_filter` for strict facet filtering.【F:embkit/lib/query_ops/__init__.py†L187-L205】
+
+```python
+import numpy as np
+from embkit.lib.query_ops import subspace_similarity
+
+mask = np.array([1.0, 0.0, 0.0], dtype=np.float32)  # focus on resolution dimension
+q = np.array([0.9, 0.2, 0.1], dtype=np.float32)
+doc = np.array([0.8, -0.1, 0.0], dtype=np.float32)
+print(subspace_similarity(q, doc, mask))
+```
+
+### 10. Hybrid Sparse + Dense Retrieval (Representation & Indexing)
+
+Fuse BM25 and embedding scores using `hybrid_score_mix`. Provide aligned score arrays and tune the interpolation weight to fit your domain.【F:embkit/lib/query_ops/__init__.py†L207-L218】
+
+```python
+from embkit.lib.query_ops import hybrid_score_mix
+
+bm25 = [2.0, 1.5, 0.5]
+dense = [0.2, 0.7, 0.9]
+print(hybrid_score_mix(bm25, dense, weight=0.6))
+```
+
 ## Regenerating Demo Binaries
 
 The demo's binary artifacts (embeddings, FAISS index shards, and helper vectors)

--- a/embkit/lib/query_ops/__init__.py
+++ b/embkit/lib/query_ops/__init__.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-from typing import List, Tuple
+from typing import List, Sequence, Tuple
 import numpy as np
 from ..utils import l2n
 
@@ -14,27 +14,65 @@ def directional(q: np.ndarray, v_dir: np.ndarray, D: np.ndarray, alpha: float) -
     order = np.argsort(-s)
     return [(int(i), float(s[i])) for i in order]
 
+
+def directional_search(q: np.ndarray, v_dir: np.ndarray, D: np.ndarray, alpha: float = 0.5) -> List[int]:
+    """Return row indices sorted by cosine to ``q + alpha * v_dir``."""
+    ranked = directional(q, v_dir, D, alpha)
+    return [idx for idx, _ in ranked]
+
 def contrastive(q: np.ndarray, v_neg: np.ndarray, D: np.ndarray, lam: float) -> List[Tuple[int, float]]:
     lam = float(lam)
     s = _cos_many(q, D) - lam * _cos_many(v_neg, D)
     order = np.argsort(-s)
     return [(int(i), float(s[i])) for i in order]
 
-def compose_and(qs: List[np.ndarray]) -> np.ndarray:
+
+def contrastive_score(q: np.ndarray, v_neg: np.ndarray, d: np.ndarray, lam: float = 1.0) -> float:
+    """Return contrastive score for a single document vector ``d``."""
+    qn = l2n(q.astype(np.float32), axis=None)
+    nn = l2n(v_neg.astype(np.float32), axis=None)
+    dn = l2n(d.astype(np.float32), axis=None)
+    return float(dn @ qn - float(lam) * (dn @ nn))
+
+def compose_and(qs: Sequence[np.ndarray]) -> np.ndarray:
     if len(qs) == 0: raise ValueError("compose_and needs at least one vector")
     v = np.zeros_like(qs[0], dtype=np.float32)
     for q in qs: v += q.astype(np.float32)
     return l2n(v, axis=None)
 
-def compose_or(scores: List[np.ndarray]) -> np.ndarray:
+def compose_or(scores: Sequence[np.ndarray]) -> np.ndarray:
     if len(scores) == 0: raise ValueError("compose_or needs at least one score array")
     out = scores[0].astype(np.float32)
     for s in scores[1:]:
         out = np.maximum(out, s.astype(np.float32))
     return out
 
+
+def facet_subsearch(query_terms: Sequence[np.ndarray], doc_vectors: np.ndarray, top_k: int = 10) -> List[Tuple[int, float]]:
+    """Return docs that repeatedly appear across facet sub-searches."""
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    if len(query_terms) == 0:
+        raise ValueError("query_terms must be non-empty")
+    Dn = l2n(doc_vectors.astype(np.float32), axis=1)
+    if Dn.shape[0] == 0:
+        return []
+    agg: dict[int, float] = {}
+    for term in query_terms:
+        sims = Dn @ l2n(term.astype(np.float32), axis=None)
+        idx = np.argpartition(-sims, min(top_k, sims.shape[0]-1))[:top_k]
+        for i in idx:
+            agg[i] = agg.get(int(i), 0.0) + float(sims[i])
+    ranked = sorted(agg.items(), key=lambda x: -x[1])
+    return ranked[:min(top_k, len(ranked))]
+
 def analogical(a: np.ndarray, b: np.ndarray, c: np.ndarray) -> np.ndarray:
     return l2n(b - a + c, axis=None)
+
+
+def analogical_query(a: str, b: str, c: str, embeddings: dict[str, np.ndarray]) -> np.ndarray:
+    """Convenience helper mirroring the classic analogy ``b - a + c``."""
+    return analogical(embeddings[a], embeddings[b], embeddings[c])
 
 def mmr(q: np.ndarray, D: np.ndarray, k: int, lam: float) -> List[int]:
     k = int(k); lam = float(lam)
@@ -54,11 +92,26 @@ def mmr(q: np.ndarray, D: np.ndarray, k: int, lam: float) -> List[int]:
         chosen.append(i)
     return chosen
 
+
+def mmr_select(q: np.ndarray, D: np.ndarray, k: int = 10, lam: float = 0.7) -> List[int]:
+    """Wrapper returning indices picked by maximal marginal relevance."""
+    return mmr(q, D, k, lam)
+
 def temporal(scores: np.ndarray, ages_days: np.ndarray, gamma: float) -> np.ndarray:
     return (scores.astype(np.float32) * np.exp(-float(gamma) * ages_days.astype(np.float32))).astype(np.float32)
 
+
+def temporal_score(score: float, age_days: float, gamma: float = 0.01) -> float:
+    """Apply exponential decay to a single score."""
+    return float(temporal(np.array([score], dtype=np.float32), np.array([age_days], dtype=np.float32), gamma)[0])
+
 def personalize(q: np.ndarray, u: np.ndarray, D: np.ndarray, beta: float) -> np.ndarray:
     return (_cos_many(q, D) + float(beta) * _cos_many(u, D)).astype(np.float32)
+
+
+def personalized_score(q: np.ndarray, u: np.ndarray, d: np.ndarray, beta: float = 0.3) -> float:
+    """Return personalized score for a single document vector ``d``."""
+    return float(personalize(q, u, d[None, :], beta)[0])
 
 def cone_filter(q: np.ndarray, D: np.ndarray, cos_min: float) -> List[int]:
     s = _cos_many(q, D)
@@ -76,3 +129,42 @@ def mahalanobis_diag(u: np.ndarray, v: np.ndarray, w: np.ndarray) -> float:
     diff = (u.astype(np.float32) - v.astype(np.float32))
     if np.any(w < 0): raise ValueError("weights must be nonnegative")
     return float(np.sqrt(np.sum((diff * np.sqrt(w.astype(np.float32)))**2, dtype=np.float32)))
+
+
+def late_interaction_score(query_vecs: np.ndarray, doc_vecs: np.ndarray) -> float:
+    """ColBERT-style MaxSim scoring for multi-vector interactions."""
+    if query_vecs.ndim != 2 or doc_vecs.ndim != 2:
+        raise ValueError("expected 2D arrays for query and document vectors")
+    Q = l2n(query_vecs.astype(np.float32), axis=1)
+    Dn = l2n(doc_vecs.astype(np.float32), axis=1)
+    score = 0.0
+    for q in Q:
+        sims = Dn @ q
+        score += float(np.max(sims))
+    return float(score)
+
+
+def subspace_similarity(q: np.ndarray, d: np.ndarray, mask: np.ndarray) -> float:
+    """Cosine similarity restricted to an attribute mask."""
+    if mask.shape != q.shape:
+        raise ValueError("mask must match vector shape")
+    q_sub = q.astype(np.float32) * mask.astype(np.float32)
+    d_sub = d.astype(np.float32) * mask.astype(np.float32)
+    if not np.any(q_sub) or not np.any(d_sub):
+        return 0.0
+    return float(l2n(q_sub, axis=None) @ l2n(d_sub, axis=None))
+
+
+def hybrid_score_mix(bm25_scores: Sequence[float], dense_scores: Sequence[float], weight: float = 0.5) -> List[float]:
+    """Fuse aligned sparse and dense scores using linear interpolation."""
+    if len(bm25_scores) != len(dense_scores):
+        raise ValueError("score arrays must align")
+    bm25 = np.array(bm25_scores, dtype=np.float32)
+    dense = np.array(dense_scores, dtype=np.float32)
+    if bm25.size == 0:
+        return []
+    bm25_norm = bm25 / (bm25.max() + 1e-6)
+    dense_norm = dense / (dense.max() + 1e-6)
+    w = float(weight)
+    fused = w * dense_norm + (1.0 - w) * bm25_norm
+    return fused.astype(np.float32).tolist()

--- a/tests/test_query_ops.py
+++ b/tests/test_query_ops.py
@@ -1,6 +1,26 @@
 import numpy as np
-from embkit.lib.query_ops import directional, cone_filter, polytope_filter
+import pytest
+
+from embkit.lib.query_ops import (
+    analogical_query,
+    cone_filter,
+    contrastive_score,
+    directional,
+    directional_search,
+    facet_subsearch,
+    hybrid_score_mix,
+    late_interaction_score,
+    mahalanobis_diag,
+    mmr_select,
+    personalize,
+    personalized_score,
+    polytope_filter,
+    subspace_similarity,
+    temporal,
+    temporal_score,
+)
 from embkit.lib.utils import l2n
+
 
 def test_directional_shifts_rank():
     q = l2n(np.array([1.0, 0.0], dtype=np.float32), axis=None)
@@ -10,6 +30,9 @@ def test_directional_shifts_rank():
     with_dir = directional(q, vdir, D, alpha=0.8)
     assert base[0][0] == 0
     assert with_dir[0][0] == 1  # direction pushes doc1 up
+    reordered = directional_search(q, vdir, D, alpha=0.8)
+    assert reordered[0] == 1
+
 
 def test_cone_excludes_wide_angle():
     q = np.array([1.0, 0.0], dtype=np.float32)
@@ -17,9 +40,111 @@ def test_cone_excludes_wide_angle():
     keep = cone_filter(q, D, cos_min=0.8)
     assert keep == [0]  # only near q
 
+
 def test_polytope_intersection():
-    D = l2n(np.array([[0.9,0.9], [0.9,0.1], [0.1,0.9]], dtype=np.float32), axis=1)
+    D = l2n(np.array([[0.9, 0.9], [0.9, 0.1], [0.1, 0.9]], dtype=np.float32), axis=1)
     c1 = (np.array([1.0, 0.0], dtype=np.float32), 0.7)
     c2 = (np.array([0.0, 1.0], dtype=np.float32), 0.7)
     keep = polytope_filter(D, [c1, c2])
     assert keep == [0]
+
+
+def test_contrastive_penalizes_negative_concept():
+    q = np.array([0.7, 0.7], dtype=np.float32)
+    neg = np.array([0.0, 1.0], dtype=np.float32)
+    doc_ok = np.array([0.6, 0.0], dtype=np.float32)
+    doc_bad = np.array([0.1, 0.9], dtype=np.float32)
+    s_ok = contrastive_score(q, neg, doc_ok, lam=0.5)
+    s_bad = contrastive_score(q, neg, doc_bad, lam=0.5)
+    assert s_ok > s_bad
+
+
+def test_facet_subsearch_prioritizes_multi_facet_docs():
+    docs = np.array([[0.9, 0.8], [0.95, 0.1], [0.1, 0.95], [0.5, 0.5]], dtype=np.float32)
+    ml = np.array([1.0, 0.0], dtype=np.float32)
+    health = np.array([0.0, 1.0], dtype=np.float32)
+    ranked = facet_subsearch([ml, health], docs, top_k=3)
+    top_ids = [idx for idx, _ in ranked[:2]]
+    assert 0 in top_ids
+    assert 3 in top_ids
+
+
+def test_analogical_query_returns_expected_vector():
+    emb = {
+        "king": np.array([1.0, 1.0], dtype=np.float32),
+        "queen": np.array([-1.0, 1.0], dtype=np.float32),
+        "man": np.array([1.0, 0.0], dtype=np.float32),
+        "woman": np.array([-1.0, 0.0], dtype=np.float32),
+    }
+    vec = analogical_query("king", "queen", "man", emb)
+    sim_to_queen = float(vec @ l2n(emb["queen"], axis=None))
+    sim_to_king = float(vec @ l2n(emb["king"], axis=None))
+    assert sim_to_queen > sim_to_king
+
+
+def test_mmr_select_promotes_diversity():
+    rng = np.random.default_rng(0)
+    q = l2n(rng.normal(size=5).astype(np.float32), axis=None)
+    doc1 = q + 0.1
+    doc2 = q + 0.1
+    doc3 = q * 0.8
+    D = l2n(np.vstack([doc1, doc2, doc3]).astype(np.float32), axis=1)
+    selected = mmr_select(q, D, k=2, lam=0.5)
+    assert len(selected) == 2
+    assert len(set(selected)) == 2
+    assert any(i in selected for i in (0, 1))
+    assert 2 in selected
+
+
+def test_temporal_decay_prefers_recent_docs():
+    scores = np.array([0.8, 0.8], dtype=np.float32)
+    ages = np.array([10.0, 100.0], dtype=np.float32)
+    adjusted = temporal(scores, ages, gamma=0.02)
+    assert adjusted[0] > adjusted[1]
+    assert temporal_score(0.8, 10.0, gamma=0.02) == pytest.approx(adjusted[0])
+
+
+def test_personalization_boosts_profile_matches():
+    q = np.array([0.0, 1.0], dtype=np.float32)
+    user = np.array([1.0, 0.0], dtype=np.float32)
+    docs = np.array([[1.0, 0.0], [-1.0, 0.0]], dtype=np.float32)
+    scores = personalize(q, user, docs, beta=0.5)
+    assert scores[0] > scores[1]
+    assert personalized_score(q, user, docs[0], beta=0.5) == pytest.approx(scores[0])
+
+
+def test_late_interaction_score_rewards_term_coverage():
+    q_tokens = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    doc1 = np.array([[0.9, 0.1], [0.1, 0.95]], dtype=np.float32)
+    doc2 = np.array([[0.88, 0.0], [0.88, 0.0]], dtype=np.float32)
+    s1 = late_interaction_score(q_tokens, doc1)
+    s2 = late_interaction_score(q_tokens, doc2)
+    assert s1 > s2
+
+
+def test_subspace_similarity_filters_by_attribute():
+    mask = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+    q = np.array([0.9, 0.2, 0.1], dtype=np.float32)
+    doc_match = np.array([0.8, -0.3, 0.0], dtype=np.float32)
+    doc_mismatch = np.array([-0.8, 0.4, 0.2], dtype=np.float32)
+    assert subspace_similarity(q, doc_match, mask) > subspace_similarity(q, doc_mismatch, mask)
+
+
+def test_hybrid_score_mix_handles_extreme_weights():
+    bm25 = [2.0, 1.5, 0.5]
+    dense = [0.2, 0.7, 0.9]
+    all_sparse = hybrid_score_mix(bm25, dense, weight=0.0)
+    all_dense = hybrid_score_mix(bm25, dense, weight=1.0)
+    even = hybrid_score_mix(bm25, dense, weight=0.5)
+    assert np.argmax(all_sparse) == 0
+    assert np.argmax(all_dense) == 2
+    assert len(even) == 3
+
+
+def test_mahalanobis_diag_requires_nonnegative_weights():
+    u = np.array([0.0, 0.0], dtype=np.float32)
+    v = np.array([1.0, 1.0], dtype=np.float32)
+    w = np.array([1.0, 4.0], dtype=np.float32)
+    assert mahalanobis_diag(u, v, w) > 0
+    with pytest.raises(ValueError):
+        mahalanobis_diag(u, v, np.array([1.0, -1.0], dtype=np.float32))


### PR DESCRIPTION
## Summary
- add helper functions that back each advanced embedding use case (directional bias, contrastive filtering, facet merging, analogical reasoning, MMR, temporal decay, personalization, late interaction, attribute masks, and hybrid fusion)
- document every advanced embedding pattern in the README with runnable snippets so users can reproduce the scenarios
- extend query-ops unit tests to confirm the new helpers and recipes behave as advertised

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cc5246fb248321a2d137c61a07f1f2