### PR TITLE
Handle corpus paths without directory components

### DIFF
--- a/embkit/cli/config.py
+++ b/embkit/cli/config.py
@@ -65,7 +65,8 @@ def load_config(path: str) -> Config:
     with open(path, "r", encoding="utf-8") as f:
         y = yaml.safe_load(f)
     cfg = Config(**y)
-    if not os.path.exists(cfg.paths.corpus):
-        os.makedirs(os.path.dirname(cfg.paths.corpus), exist_ok=True)
+    corpus_dir = os.path.dirname(cfg.paths.corpus)
+    if corpus_dir and not os.path.exists(corpus_dir):
+        os.makedirs(corpus_dir, exist_ok=True)
     os.makedirs(cfg.paths.output_dir, exist_ok=True)
     return cfg

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,0 +1,27 @@
+import textwrap
+
+from embkit.cli.config import load_config
+
+
+def test_load_config_allows_corpus_without_directory(tmp_path):
+    output_dir = tmp_path / "outputs"
+    config_content = textwrap.dedent(
+        f"""
+        model:
+          name: test
+        index:
+          kind: flatip
+        paths:
+          corpus: corpus.txt
+          output_dir: {output_dir}
+        """
+    ).strip()
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(config_content)
+
+    cfg = load_config(str(config_path))
+
+    assert cfg.paths.corpus == "corpus.txt"
+    assert cfg.paths.output_dir == str(output_dir)
+    assert output_dir.is_dir()


### PR DESCRIPTION
## Summary
- avoid calling os.makedirs with an empty directory when preparing corpus paths
- add a regression test to confirm corpus paths without directories load successfully

## Testing
- pytest tests/test_cli_config.py

------
https://chatgpt.com/codex/tasks/task_e_68cc833394208321b880b1351ee9886d