### PR TITLE
Handle utils writes without directory components

### DIFF
--- a/embkit/lib/utils/__init__.py
+++ b/embkit/lib/utils/__init__.py
@@ -49,13 +49,17 @@ def read_jsonl(path: str) -> List[dict]:
     return out
 
 def write_jsonl(path: str, rows: Iterable[dict]) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
     with open(path, "w", encoding="utf-8") as f:
         for r in rows:
             f.write(json.dumps(r, ensure_ascii=False) + "\n")
 
 def save_npy(path: str, arr: np.ndarray) -> None:
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
     np.save(path, arr.astype(np.float32, copy=False))
 
 def load_npy(path: str) -> np.ndarray:

--- a/embkit/lib/utils/demo_data.py
+++ b/embkit/lib/utils/demo_data.py
@@ -5,7 +5,9 @@ from . import l2n, write_jsonl, save_npy, set_determinism
 
 def generate_tiny(path_corpus: str, path_emb: str, n: int = 200, d: int = 32, seed: int = 42) -> None:
     set_determinism(seed)
-    os.makedirs(os.path.dirname(path_corpus), exist_ok=True)
+    directory = os.path.dirname(path_corpus)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
     ids = []
     rows = []
     t0 = int(time.time())
@@ -33,5 +35,6 @@ def generate_tiny(path_corpus: str, path_emb: str, n: int = 200, d: int = 32, se
     D = l2n(X2 @ W, axis=1)
     write_jsonl(path_corpus, rows)
     save_npy(path_emb, D)
-    with open(os.path.join(os.path.dirname(path_corpus), "ids.txt"), "w", encoding="utf-8") as f:
+    ids_path = os.path.join(directory, "ids.txt") if directory else "ids.txt"
+    with open(ids_path, "w", encoding="utf-8") as f:
         for s in ids: f.write(s+"\n")

--- a/tests/test_utils_io.py
+++ b/tests/test_utils_io.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import numpy as np
+
+from embkit.lib.utils import read_jsonl, write_jsonl, save_npy, load_npy
+from embkit.lib.utils.demo_data import generate_tiny
+
+
+def test_write_jsonl_no_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    rows = [{"a": 1}, {"b": 2}]
+
+    write_jsonl("data.jsonl", rows)
+
+    path = tmp_path / "data.jsonl"
+    assert path.is_file()
+    assert read_jsonl("data.jsonl") == rows
+
+
+def test_save_npy_no_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    arr = np.random.rand(2, 3).astype(np.float32)
+
+    save_npy("array.npy", arr)
+
+    path = tmp_path / "array.npy"
+    assert path.is_file()
+    loaded = load_npy("array.npy")
+    np.testing.assert_allclose(loaded, arr, rtol=1e-6, atol=1e-6)
+
+
+def test_generate_tiny_no_directory(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+
+    generate_tiny("corpus.jsonl", "embeddings.npy", n=4, d=4, seed=0)
+
+    assert (tmp_path / "corpus.jsonl").is_file()
+    assert (tmp_path / "embeddings.npy").is_file()
+    assert (tmp_path / "ids.txt").is_file()
+
+    with open(tmp_path / "ids.txt", "r", encoding="utf-8") as f:
+        ids = [line.strip() for line in f if line.strip()]
+    assert len(ids) == 4


### PR DESCRIPTION
## Summary
- guard `write_jsonl`, `save_npy`, and `generate_tiny` so they only create directories when a parent folder is specified
- add regression tests covering writes with bare filenames in the working directory

## Testing
- pytest tests/test_utils_io.py

------
https://chatgpt.com/codex/tasks/task_e_68cc848033648321be80828da79269ed