### PR TITLE
Fix eval CLI for small corpora and add regression test

### DIFF
--- a/embkit/cli/eval.py
+++ b/embkit/cli/eval.py
@@ -18,7 +18,7 @@ def run(config: str):
     rows = read_jsonl(cfg.paths.corpus)
     qids = [f"q{i:03d}" for i in range(min(5, len(rows)))]
     rankings = {qid: [rows[i]["id"] for i in range(len(rows))][:10] for qid in qids}
-    labels = {qids[0]: set([rows[0]["id"]]), qids[1]: set([rows[1]["id"]])}
+    labels = {qid: {rows[i]["id"]} for i, qid in enumerate(qids) if i < len(rows)}
     times = {qid: 5.0 for qid in qids}
     ages = {qid: [0.0]*10 for qid in qids}
     metrics = compute_all(labels, rankings, times, ages)

--- a/tests/test_cli_eval.py
+++ b/tests/test_cli_eval.py
@@ -1,0 +1,47 @@
+import json
+import textwrap
+
+import pytest
+
+from embkit.cli.eval import run as eval_run
+
+
+def _write_corpus(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+@pytest.mark.parametrize("rows", [[], [{"id": "doc-0"}]])
+def test_eval_cli_handles_small_corpus(tmp_path, rows):
+    corpus_path = tmp_path / "corpus.jsonl"
+    output_dir = tmp_path / "outputs"
+    _write_corpus(corpus_path, rows)
+
+    config_content = textwrap.dedent(
+        f"""
+        model:
+          name: test-model
+        index:
+          kind: flatip
+        paths:
+          corpus: {corpus_path}
+          output_dir: {output_dir}
+        """
+    ).strip()
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(config_content)
+
+    eval_run(str(config_path))
+
+    metrics_path = output_dir / "metrics.jsonl"
+    assert metrics_path.is_file()
+
+    records = [json.loads(line) for line in metrics_path.read_text().splitlines() if line.strip()]
+    assert len(records) >= 7
+    for record in records:
+        assert record["metric"]
+        assert isinstance(record["value"], (int, float))
+        assert record["exp_id"] == "demo"
+        assert record["split"] == "demo"


### PR DESCRIPTION
## Summary
- guard the eval CLI's synthetic label generation so it only touches existing rows
- add regression coverage to ensure the CLI produces metrics for empty or single-row corpora

## Testing
- pytest tests/test_cli_eval.py

------
https://chatgpt.com/codex/tasks/task_e_68cc85741454832191b055b41b2fc7a0