### PR TITLE
Add Hugging Face encoder support and configuration updates

### DIFF
--- a/embkit/lib/models/__init__.py
+++ b/embkit/lib/models/__init__.py
@@ -1,1 +1,63 @@
-# package marker
+from __future__ import annotations
+
+from typing import Protocol, Sequence
+
+import numpy as np
+
+from .dummy import DummyEncoder
+
+try:  # Optional Hugging Face support
+    from .hf import (
+        MODEL_REGISTRY,
+        HuggingFaceEncoder,
+        HuggingFaceModelConfig,
+        resolve_model_name,
+    )
+except Exception:  # pragma: no cover - optional dependency
+    MODEL_REGISTRY = {}
+    HuggingFaceEncoder = None  # type: ignore
+    HuggingFaceModelConfig = None  # type: ignore
+    resolve_model_name = lambda name: name  # type: ignore
+
+
+class QueryDocumentEncoder(Protocol):
+    """Common interface for encoders supporting batch query/document encoding."""
+
+    def encode_queries(self, texts: Sequence[str]) -> np.ndarray: ...
+
+    def encode_documents(self, texts: Sequence[str]) -> np.ndarray: ...
+
+
+def create_encoder(model_cfg, seed: int, *, dimension: int | None = None) -> QueryDocumentEncoder:
+    """Instantiate an encoder based on the provided model configuration."""
+
+    provider = getattr(model_cfg, "provider", "dummy")
+    if provider == "dummy":
+        d = dimension if dimension is not None else getattr(model_cfg, "dim", 32)
+        return DummyEncoder(d=int(d), seed=seed)
+    if provider == "huggingface":
+        if HuggingFaceEncoder is None or HuggingFaceModelConfig is None:
+            raise RuntimeError(
+                "Hugging Face dependencies are not available. Install torch, transformers, "
+                "sentence-transformers, and huggingface-hub."
+            )
+        cfg = HuggingFaceModelConfig(
+            name_or_path=resolve_model_name(getattr(model_cfg, "name")),
+            batch_size=getattr(model_cfg, "batch_size", 32),
+            max_length=getattr(model_cfg, "max_length", 512),
+            cache_dir=getattr(model_cfg, "cache_dir", None),
+            revision=getattr(model_cfg, "revision", None),
+            seed=seed,
+        )
+        return HuggingFaceEncoder(cfg)
+    raise ValueError(f"Unknown model provider: {provider}")
+
+
+__all__ = [
+    "DummyEncoder",
+    "HuggingFaceEncoder",
+    "MODEL_REGISTRY",
+    "QueryDocumentEncoder",
+    "create_encoder",
+    "resolve_model_name",
+]

--- a/embkit/lib/models/dummy.py
+++ b/embkit/lib/models/dummy.py
@@ -1,17 +1,50 @@
 from __future__ import annotations
+
+from typing import Iterable, Sequence
+
 import numpy as np
+
 from ..utils import l2n, set_determinism
 
+
 class DummyEncoder:
-    """Deterministic hash 3-gram encoder for queries."""
+    """Deterministic hash 3-gram encoder for queries/documents."""
+
     def __init__(self, d: int = 32, seed: int = 42):
         set_determinism(seed)
         self.d = int(d)
-    def encode_query(self, text: str) -> np.ndarray:
+
+    def _encode(self, text: str) -> np.ndarray:
         v = np.zeros(self.d, dtype=np.float32)
         t = f"##{text.lower()}##"
-        for i in range(len(t)-2):
-            tri = t[i:i+3]
+        for i in range(len(t) - 2):
+            tri = t[i : i + 3]
             h = hash(tri) % self.d
             v[h] += 1.0
         return l2n(v, axis=None)
+
+    def encode_query(self, text: str) -> np.ndarray:
+        """Encode a single query string (legacy API)."""
+
+        return self._encode(text)
+
+    def encode_queries(self, texts: Sequence[str]) -> np.ndarray:
+        """Encode a batch of queries into L2-normalized vectors."""
+
+        return self._encode_many(texts)
+
+    def encode_document(self, text: str) -> np.ndarray:
+        """Encode a single document string."""
+
+        return self._encode(text)
+
+    def encode_documents(self, texts: Sequence[str]) -> np.ndarray:
+        """Encode a batch of documents into L2-normalized vectors."""
+
+        return self._encode_many(texts)
+
+    def _encode_many(self, texts: Iterable[str]) -> np.ndarray:
+        vecs = [self._encode(t) for t in texts]
+        if not vecs:
+            return np.zeros((0, self.d), dtype=np.float32)
+        return np.stack(vecs, axis=0).astype(np.float32, copy=False)

--- a/embkit/lib/models/hf.py
+++ b/embkit/lib/models/hf.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Optional, Sequence
+
+import numpy as np
+
+from ..utils import l2n, set_determinism
+
+
+MODEL_REGISTRY = {
+    "e5-mistral": "intfloat/e5-mistral-7b-instruct",
+    "mxbai-large": "mixedbread-ai/mxbai-embed-large-v1",
+    "sfr-mistral": "Salesforce/SFR-Embedding-Mistral",
+    "gist-embedding": "avsolatorio/GIST-Embedding-v0",
+    "gte-large": "thenlper/gte-large",
+}
+
+
+@dataclass
+class HuggingFaceModelConfig:
+    name_or_path: str
+    batch_size: int = 32
+    max_length: int = 512
+    cache_dir: Optional[str] = None
+    revision: Optional[str] = None
+    seed: int = 42
+
+
+class HuggingFaceEncoder:
+    """Sentence-Transformer backed encoder operating purely on CPU."""
+
+    def __init__(self, cfg: HuggingFaceModelConfig):
+        try:
+            import torch
+        except ImportError as exc:  # pragma: no cover - exercised via tests with mocks
+            raise RuntimeError(
+                "torch is required for HuggingFaceEncoder; install torch>=2.1"
+            ) from exc
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "sentence-transformers is required for HuggingFaceEncoder"
+            ) from exc
+
+        set_determinism(cfg.seed)
+        torch.manual_seed(cfg.seed)
+        try:  # pragma: no cover - backend availability varies
+            torch.use_deterministic_algorithms(True)
+        except Exception:
+            pass
+        torch.set_num_threads(1)
+
+        model_id = MODEL_REGISTRY.get(cfg.name_or_path, cfg.name_or_path)
+        init_kwargs = {"device": "cpu"}
+        if cfg.cache_dir:
+            init_kwargs["cache_folder"] = cfg.cache_dir
+        if cfg.revision:
+            init_kwargs["model_kwargs"] = {"revision": cfg.revision}
+        self._model = SentenceTransformer(model_id, **init_kwargs)
+        if cfg.max_length:
+            try:
+                self._model.max_seq_length = int(cfg.max_length)
+            except AttributeError:  # pragma: no cover - older st versions
+                pass
+
+        self.batch_size = int(cfg.batch_size)
+        dim_getter = getattr(self._model, "get_sentence_embedding_dimension", None)
+        self.d = 0
+        if callable(dim_getter):
+            try:
+                maybe_dim = dim_getter()
+            except TypeError:  # pragma: no cover - signature differences
+                maybe_dim = dim_getter
+            if maybe_dim:
+                self.d = int(maybe_dim)
+        if self.d <= 0:
+            # Fallback: run a dummy encode to infer dimensionality
+            dummy = self._model.encode([""])
+            dummy_arr = np.asarray(dummy, dtype=np.float32)
+            if dummy_arr.ndim != 2:
+                dummy_arr = np.atleast_2d(dummy_arr)
+            self.d = int(dummy_arr.shape[1])
+
+    def encode_queries(self, texts: Sequence[str]) -> np.ndarray:
+        return self._encode(texts)
+
+    def encode_documents(self, texts: Sequence[str]) -> np.ndarray:
+        return self._encode(texts)
+
+    def encode_query(self, text: str) -> np.ndarray:
+        return self.encode_queries([text])[0]
+
+    def encode_document(self, text: str) -> np.ndarray:
+        return self.encode_documents([text])[0]
+
+    def _encode(self, texts: Iterable[str]) -> np.ndarray:
+        texts_list = list(texts)
+        if not texts_list:
+            return np.zeros((0, self.d), dtype=np.float32)
+        embeds = self._model.encode(
+            texts_list,
+            batch_size=self.batch_size,
+            convert_to_numpy=True,
+            show_progress_bar=False,
+            normalize_embeddings=False,
+        )
+        arr = np.asarray(embeds, dtype=np.float32)
+        if arr.ndim == 1:
+            arr = arr[None, :]
+        return l2n(arr, axis=1)
+
+
+def resolve_model_name(name: str) -> str:
+    """Return the full Hugging Face identifier for an alias."""
+
+    return MODEL_REGISTRY.get(name, name)

--- a/experiments/configs/hf_mxbai.yaml
+++ b/experiments/configs/hf_mxbai.yaml
@@ -1,0 +1,18 @@
+model:
+  provider: "huggingface"
+  name: "mxbai-large"
+  batch_size: 32
+  max_length: 512
+index:
+  kind: "ivfpq"
+  params:
+    nlist: 2048
+    m: 32
+    nbits: 8
+    nprobe: 16
+paths:
+  corpus: "data/custom/corpus.jsonl"
+  embeddings: "data/custom/mxbai_embeddings.npy"
+  output_dir: "experiments/runs/hf_mxbai"
+seed: 123
+top_k: 20

--- a/experiments/configs/mteb_e5.yaml
+++ b/experiments/configs/mteb_e5.yaml
@@ -1,0 +1,13 @@
+model:
+  provider: "huggingface"
+  name: "e5-mistral"
+  batch_size: 16
+  max_length: 512
+index:
+  kind: "flatip"
+paths:
+  corpus: "data/mteb/corpus.jsonl"
+  embeddings: "data/mteb/e5_embeddings.npy"
+  output_dir: "experiments/runs/mteb_e5"
+seed: 42
+top_k: 10

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,7 @@ pyyaml==6.0.1
 typer==0.12.3
 pytest==7.4.4
 tqdm==4.66.2
+torch==2.1.0
+transformers==4.36.0
+sentence-transformers==2.3.0
+huggingface-hub==0.20.0

--- a/tests/test_cli_config.py
+++ b/tests/test_cli_config.py
@@ -1,6 +1,8 @@
 import textwrap
 
-from embkit.cli.config import load_config
+import pytest
+
+from embkit.cli.config import Config, ModelCfg, load_config
 
 
 def test_load_config_allows_corpus_without_directory(tmp_path):
@@ -8,7 +10,7 @@ def test_load_config_allows_corpus_without_directory(tmp_path):
     config_content = textwrap.dedent(
         f"""
         model:
-          name: test
+          name: dummy-encoder
         index:
           kind: flatip
         paths:
@@ -25,3 +27,23 @@ def test_load_config_allows_corpus_without_directory(tmp_path):
     assert cfg.paths.corpus == "corpus.txt"
     assert cfg.paths.output_dir == str(output_dir)
     assert output_dir.is_dir()
+
+
+def test_model_cfg_validates_hf_alias():
+    cfg = Config(
+        model=ModelCfg(provider="huggingface", name="e5-mistral"),
+        index={"kind": "flatip"},
+        paths={"corpus": "corpus.txt", "output_dir": "out"},
+    )
+
+    assert cfg.model.name == "e5-mistral"
+    assert cfg.model.provider == "huggingface"
+
+
+def test_model_cfg_rejects_unknown_hf_alias():
+    with pytest.raises(ValueError):
+        Config(
+            model=ModelCfg(provider="huggingface", name="unknown-model"),
+            index={"kind": "flatip"},
+            paths={"corpus": "corpus.txt", "output_dir": "out"},
+        )

--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -1,0 +1,53 @@
+import numpy as np
+import pytest
+
+from embkit.cli.config import ModelCfg
+from embkit.lib.models import DummyEncoder, create_encoder, resolve_model_name
+
+
+def test_create_encoder_returns_dummy_encoder(monkeypatch):
+    cfg = ModelCfg(name="dummy-encoder")
+    enc = create_encoder(cfg, seed=123, dimension=16)
+
+    assert isinstance(enc, DummyEncoder)
+
+    vecs = enc.encode_queries(["hello", "world"])
+    assert vecs.shape == (2, 16)
+    norms = np.linalg.norm(vecs, axis=1)
+    assert np.allclose(norms, 1.0, atol=1e-5)
+
+
+def test_create_encoder_hf_uses_registry(monkeypatch):
+    created = {}
+
+    class StubEncoder:
+        def __init__(self, cfg):
+            created["cfg"] = cfg
+
+        def encode_queries(self, texts):
+            return np.zeros((len(texts), 4), dtype=np.float32)
+
+        def encode_documents(self, texts):
+            return np.zeros((len(texts), 4), dtype=np.float32)
+
+    monkeypatch.setattr("embkit.lib.models.HuggingFaceEncoder", StubEncoder)
+
+    cfg = ModelCfg(provider="huggingface", name="gte-large", batch_size=8, max_length=128)
+    enc = create_encoder(cfg, seed=7)
+
+    assert isinstance(enc, StubEncoder)
+    hf_cfg = created["cfg"]
+    assert hf_cfg.name_or_path == resolve_model_name("gte-large")
+    assert hf_cfg.batch_size == 8
+    assert hf_cfg.max_length == 128
+    assert hf_cfg.seed == 7
+
+
+def test_create_encoder_hf_without_dependencies(monkeypatch):
+    monkeypatch.setattr("embkit.lib.models.HuggingFaceEncoder", None)
+    monkeypatch.setattr("embkit.lib.models.HuggingFaceModelConfig", None)
+
+    cfg = ModelCfg(provider="huggingface", name="gte-large")
+
+    with pytest.raises(RuntimeError):
+        create_encoder(cfg, seed=0)


### PR DESCRIPTION
## Summary
- add a CPU-only Hugging Face encoder module with a model factory and alias registry
- extend the CLI config schema plus index/search flows to encode via the factory and persist metadata
- document the new workflow, add example configs, and cover it with tests and dependencies

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc8e02f28c8321b405481febcf4c3c