### PR TITLE
Make DummyEncoder hashing deterministic across processes

### DIFF
--- a/tests/test_model_factory.py
+++ b/tests/test_model_factory.py
@@ -17,6 +17,17 @@ def test_create_encoder_returns_dummy_encoder(monkeypatch):
     assert np.allclose(norms, 1.0, atol=1e-5)
 
 
+def test_dummy_encoder_produces_stable_vectors_across_instances():
+    text = "Deterministic hashing"
+    enc1 = DummyEncoder(d=16, seed=777)
+    enc2 = DummyEncoder(d=16, seed=777)
+
+    vec1 = enc1.encode_document(text)
+    vec2 = enc2.encode_document(text)
+
+    np.testing.assert_array_equal(vec1, vec2)
+
+
 def test_create_encoder_hf_uses_registry(monkeypatch):
     created = {}
 


### PR DESCRIPTION
## Summary
- replace Python's hash() usage in DummyEncoder with a seed-keyed BLAKE2b digest for stable bucket assignment and document the behavior
- store the encoder seed for reuse in the hashing routine so bucket indices remain reproducible
- add a regression test that ensures two fresh encoders with the same seed emit identical vectors

## Testing
- pytest tests/test_model_factory.py

------
https://chatgpt.com/codex/tasks/task_e_68cc9e129f5483218279fa20bd1425c2