### PR TITLE
Fix nullspace projection for dependent directions

### DIFF
--- a/tests/test_nullspace.py
+++ b/tests/test_nullspace.py
@@ -21,3 +21,35 @@ def test_remove_directions_batch_matches_single():
     projected = remove_directions(vectors, direction)
     expected = np.stack([remove_direction(v, direction) for v in vectors])
     assert np.allclose(projected, expected, atol=1e-6)
+
+
+def test_remove_directions_repeated_direction_zeroes_component():
+    vectors = np.array([[1.0, 0.0, 0.0]], dtype=np.float32)
+    repeated = np.array(
+        [[1.0, 0.0, 0.0], [1.0, 0.0, 0.0]], dtype=np.float32
+    )
+    projected = remove_directions(vectors, repeated)
+    expected = np.zeros_like(vectors)
+    assert np.allclose(projected, expected, atol=1e-6)
+
+
+def test_remove_directions_linearly_dependent_matches_unique():
+    vectors = np.array(
+        [
+            [1.0, 2.0, -0.5],
+            [-3.0, 0.5, 1.5],
+        ],
+        dtype=np.float32,
+    )
+    dependent = np.array(
+        [
+            [1.0, 0.0, 0.0],
+            [2.0, 0.0, 0.0],  # collinear with the first direction
+            [0.0, 1.0, 0.0],
+        ],
+        dtype=np.float32,
+    )
+    unique = np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]], dtype=np.float32)
+    projected_dependent = remove_directions(vectors, dependent)
+    projected_unique = remove_directions(vectors, unique)
+    assert np.allclose(projected_dependent, projected_unique, atol=1e-6)


### PR DESCRIPTION
## Summary
- orthonormalize nullspace projections via SVD so dependent directions do not double-count
- add regression tests covering repeated and linearly dependent projection directions

## Testing
- pytest tests/test_nullspace.py

------
https://chatgpt.com/codex/tasks/task_e_68cc9efc2ec88321af1b13de05f8a0ed